### PR TITLE
LPS-85413 Avoid receive an empty page after adding comment in Wiki

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/RenderPortletAction.java
+++ b/portal-impl/src/com/liferay/portal/action/RenderPortletAction.java
@@ -112,7 +112,7 @@ public class RenderPortletAction extends Action {
 			decorate);
 
 		PortletContainerUtil.processPublicRenderParameters(
-			request, themeDisplay.getLayout());
+			request, themeDisplay.getLayout(), portlet);
 
 		PortletContainerUtil.render(request, response, portlet);
 


### PR DESCRIPTION
Hi @hudakl ,

The commit of LPS-85413 5c8180a78375f1bd256a299e0415a167602726d0 caused one issue that portal return an empty wiki page after adding comment in wiki page, the empty wiki page shown this "Error
This page is empty. Use the buttons below to create it or to search for the words in the title." but the comment have been added to the wiki page sucessfully.

For reproduce:
1>No matter with or without the commit of LPS-85413, I can not reproduce this issue that described in this ticket https://issues.liferay.com/browse/LPS-85413 by browser manually.
2> For the portal return empty wiki page issue, I can not reprodece it by browser manually, but it can be reproduced by the benchmark test case Wiki, The url that used by the test case wiki worked well.

This pull can fixed the issue for benchmark test, as I can not reproduce the origin issue in https://issues.liferay.com/browse/LPS-85413, could you please check if this pull block any thing about the origin fix?

cc @shuyangzhou

Thanks
Lily

